### PR TITLE
fix(metadata): Add missing namespace prefixes to `Rector` configuration and format imports order and update `ECS` sets version.

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -41,7 +41,11 @@ return ECSConfig::configure()
     ->withConfiguredRule(
         OrderedImportsFixer::class,
         [
-            'imports_order' => ['class', 'function', 'const'],
+            'imports_order' => [
+                'class',
+                'function',
+                'const',
+            ],
             'sort_algorithm' => 'alpha',
         ],
     )
@@ -59,7 +63,7 @@ return ECSConfig::configure()
             __DIR__ . '/tests',
         ],
     )
-    ->withPhpCsFixerSets(perCS20: true)
+    ->withPhpCsFixerSets(perCS30: true)
     ->withPreparedSets(
         cleanCode: true,
         comments: true,

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-return static function (Rector\Config\RectorConfig $rectorConfig): void {
+return static function (\Rector\Config\RectorConfig $rectorConfig): void {
     $rectorConfig->parallel();
 
     $rectorConfig->importNames();
@@ -16,13 +16,13 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
 
     $rectorConfig->sets(
         [
-            Rector\Set\ValueObject\SetList::PHP_81,
-            Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_81,
-            Rector\Set\ValueObject\SetList::TYPE_DECLARATION,
+            \Rector\Set\ValueObject\SetList::PHP_81,
+            \Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_81,
+            \Rector\Set\ValueObject\SetList::TYPE_DECLARATION,
         ],
     );
 
     $rectorConfig->rule(
-        Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector::class
+        \Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector::class
     );
 };


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP code style configuration to use PHP CS Fixer 3.0 standards (previously 2.0)
  * Updated code quality tool namespace references for improved compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->