### PR TITLE
fix(metadata): Correctly configure skip rules for `TypedPropertyFromCreateMockAssignRector` in `rector.php` and update Composer scripts.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
             "curl -fsSL -o infection.json5 https://raw.githubusercontent.com/yii2-extensions/template/main/infection.json5",
             "curl -fsSL -o phpstan.neon https://raw.githubusercontent.com/yii2-extensions/template/main/phpstan.neon",
             "curl -fsSL -o phpunit.xml.dist https://raw.githubusercontent.com/yii2-extensions/template/main/phpunit.xml.dist",
+            "curl -fsSL -o rector.php https://raw.githubusercontent.com/yii2-extensions/template/main/.styleci.yml",
             "curl -fsSL -o rector.php https://raw.githubusercontent.com/yii2-extensions/template/main/rector.php"
         ],
         "tests": "./vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -56,11 +56,11 @@
             "curl -fsSL -o .editorconfig https://raw.githubusercontent.com/yii2-extensions/template/main/.editorconfig",
             "curl -fsSL -o .gitattributes https://raw.githubusercontent.com/yii2-extensions/template/main/.gitattributes",
             "curl -fsSL -o .gitignore https://raw.githubusercontent.com/yii2-extensions/template/main/.gitignore",
+            "curl -fsSL -o .styleci.yml https://raw.githubusercontent.com/yii2-extensions/template/main/.styleci.yml",
             "curl -fsSL -o ecs.php https://raw.githubusercontent.com/yii2-extensions/template/main/ecs.php",
             "curl -fsSL -o infection.json5 https://raw.githubusercontent.com/yii2-extensions/template/main/infection.json5",
             "curl -fsSL -o phpstan.neon https://raw.githubusercontent.com/yii2-extensions/template/main/phpstan.neon",
             "curl -fsSL -o phpunit.xml.dist https://raw.githubusercontent.com/yii2-extensions/template/main/phpunit.xml.dist",
-            "curl -fsSL -o rector.php https://raw.githubusercontent.com/yii2-extensions/template/main/.styleci.yml",
             "curl -fsSL -o rector.php https://raw.githubusercontent.com/yii2-extensions/template/main/rector.php"
         ],
         "tests": "./vendor/bin/phpunit"

--- a/ecs.php
+++ b/ecs.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 use PhpCsFixer\Fixer\ClassNotation\{ClassDefinitionFixer, OrderedClassElementsFixer, OrderedTraitsFixer};
 use PhpCsFixer\Fixer\Import\{NoUnusedImportsFixer, OrderedImportsFixer};
-use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesOrderFixer;
-use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\NullableTypeDeclarationFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesOrderFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer;
+use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return ECSConfig::configure()
@@ -14,6 +15,12 @@ return ECSConfig::configure()
         ClassDefinitionFixer::class,
         [
             'space_before_parenthesis' => true,
+        ],
+    )
+    ->withConfiguredRule(
+        NullableTypeDeclarationFixer::class,
+        [
+            'syntax' => 'union',
         ],
     )
     ->withConfiguredRule(
@@ -31,6 +38,7 @@ return ECSConfig::configure()
                 'construct',
                 'destruct',
                 'magic',
+                'method_public_abstract',
                 'method_protected_abstract',
                 'method_public',
                 'method_protected',
@@ -57,6 +65,12 @@ return ECSConfig::configure()
             'null_adjustment' => 'always_last',
         ],
     )
+    ->withConfiguredRule(
+        PhpUnitTestCaseStaticMethodCallsFixer::class,
+        [
+            'call_type' => 'self',
+        ],
+    )
     ->withFileExtensions(['php'])
     ->withPaths(
         [
@@ -77,10 +91,5 @@ return ECSConfig::configure()
             NoUnusedImportsFixer::class,
             OrderedTraitsFixer::class,
             SingleQuoteFixer::class,
-        ]
-    )
-    ->withSkip(
-        [
-            NullableTypeDeclarationFixer::class,
         ]
     );

--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,15 @@ return static function (\Rector\Config\RectorConfig $rectorConfig): void {
         ],
     );
 
-    $rectorConfig->rule(
-        \Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector::class
+    $rectorConfig->skip(
+        [
+            \Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector::class,
+        ],
+    );
+
+    $rectorConfig->rules(
+        [
+            \Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector::class,
+        ],
     );
 };


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️/❌                                                              |
| New feature? | ✔️/❌                                                              |
| Breaks BC?   | ✔️/❌                                                              |
| Fixed issues | <!-- comma-separated list of tickets # fixed by the PR, if any --> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced code style/configuration to enable additional automated fixers and expanded method ordering for more consistent code structure.
  * Updated refactoring tool rules to reintroduce a simplification rule and adjust rule/skips for targeted cases.
  * Improved build/metadata sync to fetch repository-configured style settings during synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->